### PR TITLE
Update Recruitment Endpoint in Documentation for Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Search operators based on provided query parameters. Supported parameters are:
 
 #### Recruit Endpoints
 >GET: https://rhodesapi.up.railway.app/api/recruit?tag1=tagone&tag2=tagtwo&tag3=tagthree
+
 Similar to the search query but supports only up to three tags.
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Search operators based on provided query parameters. Supported parameters are:
 - `va`
 
 #### Recruit Endpoints
->GET: https://rhodesapi.up.railway.app/api/recruit?tagone=tagone&tagtwo=tagtwo&tagthree=tagthree
-
+>GET: https://rhodesapi.up.railway.app/api/recruit?tag1=tagone&tag2=tagtwo&tag3=tagthree
 Similar to the search query but supports only up to three tags.
 
 ### Notes


### PR DESCRIPTION
Hello! First of all I loved your API I personally use it for my current project which also has to do with Arknights! 

I noticed an inconsistency in the documentation for the recruitment endpoint. In the documentation, the query parameters for tags are listed as "tagone," "tagtwo," and "tagthree." However, in the actual implementation, these parameters are named "tag1," "tag2," and "tag3." 

To prevent confusion for users, I suggest updating the documentation to use "tag1," "tag2," and "tag3" to match the actual API implementation. This will make it easier for users to understand and use the recruitment endpoint effectively.

I'm willing to make these changes to the documentation to ensure a more user-friendly experience.

**Additional Information:**
The changes will be made in the "Recruitment Endpoints" section of the documentation.